### PR TITLE
Resolved some problems related to the ws connection ("web3": "^ 1.0.0-beta.26")

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,3 @@
-FROM parity/parity:v1.8.0
+FROM parity/parity:v1.8.3
 
 ENTRYPOINT ["/parity/parity"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
             # Parity data
             - ./data/parity_basepath:/root/.local/share/io.parity.ethereum
         command: 
-             --config /root/config/config.toml
+             #--config /root/config/config.toml
+             --db-path "/root/chain" --keys-path "/root/keys" --port 31313 --jsonrpc-port 8545 --jsonrpc-interface all --jsonrpc-hosts all --jsonrpc-cors '*' --ws-interface 0.0.0.0 --ws-port 8546 --ws-origins '*' --ws-hosts all --cache-size 1024  --no-dapps --ui-interface "0.0.0.0" --ui-hosts all --ui-no-validation --ipc-path "$HOME/.local/share/io.parity.ethereum/jsonrpc.ipc"
         restart: on-failure
 


### PR DESCRIPTION
- The use of config.toml is avoided because some issues have been encountered.
- It is updated to version v1.8.3 of parity