### PR TITLE
Update to Parity v1.8.6 version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,3 @@
-FROM parity/parity:v1.8.3
+FROM parity/parity:v1.8.6
 
 ENTRYPOINT ["/parity/parity"]


### PR DESCRIPTION
Updated to Parity v1.8.6 due to the following updates mainly:

- [Much faster warp sync.](https://twitter.com/5chdn/status/950831467629817857) 
- [More restrictive defaults](https://twitter.com/ParityTech/status/950808387553546242) in light of a [Talos vulnerability report](http://blog.talosintelligence.com/2018/01/vulnerability-spotlight-multiple.html?utm_source=dlvr.it&utm_medium=twitter&utm_campaign=Feed%3A+feedburner%2FTalos+%28Talos%E2%84%A2+Blog%29)

More info: [v1.8.6](https://github.com/paritytech/parity/releases/tag/v1.8.6)